### PR TITLE
Autostart capabilites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+FLAGS="autostart"
+
 all: install run
 
 run:
@@ -7,6 +9,11 @@ run:
 install:
 	@echo "Installing termDash"
 	@sudo ./scripts/install
+
+	# Adds autostart capabilities if decided
+	@if [[ "$(FLAGS)" == *"autostart"* ]]; then \
+		echo "termDash" >> '/home/$(USER)/.$(shell echo $SHELL | sed 's/.*\/bin\///g')rc'; \
+	fi 
 
 remove:
 	@echo "Removing termDash"


### PR DESCRIPTION
You can now use the flag "standalone" to install the python version and use the flag "autostart" to autostart termDash.

Example
`make all USE="standalone autostart"`
which will both install the python version and auto-open it on a new terminal.